### PR TITLE
enemy death polishing

### DIFF
--- a/Source/Slash/Public/Enemies/Enemy.h
+++ b/Source/Slash/Public/Enemies/Enemy.h
@@ -64,6 +64,11 @@ private:
 	UPROPERTY(EditDefaultsOnly, Category = VisualEffects)
 	UParticleSystem* HitParticles;
 
+	UPROPERTY()
+	AActor* CombatTarget;
+
+	UPROPERTY(EditDefaultsOnly)
+	double CombatRadius = 500.f;
 
 
 public:

--- a/Source/Slash/Public/Interfaces/HitInterface.h
+++ b/Source/Slash/Public/Interfaces/HitInterface.h
@@ -1,12 +1,9 @@
-// Fill out your copyright notice in the Description page of Project Settings.
-
 #pragma once
 
 #include "CoreMinimal.h"
 #include "UObject/Interface.h"
 #include "HitInterface.generated.h"
 
-// This class does not need to be modified.
 UINTERFACE(MinimalAPI)
 class UHitInterface : public UInterface
 {
@@ -20,8 +17,11 @@ class SLASH_API IHitInterface
 {
 	GENERATED_BODY()
 
-	// Add interface functions to this class. This is the class that will be inherited to implement this interface.
 public:
+	/*
+	 * BlueprintNativeEvent : 해당 인터페이스를 작성한 C++ 구현 함수를 Blueprint Graph에서 호출 가능
+	 * 상속받은 클래스들은 구현할 때 함수명_Implementation으로 함수명을 작성
+	 */
 	UFUNCTION(BlueprintNativeEvent)
 	void GetHit(const FVector& ImpactPoint);
 };


### PR DESCRIPTION
#3 
### 변경사항
#### Set `HealthBar` invisible when `SlashCharacter` is far away from `Enemy`
- `Enemy`의 `HealthBar`가 전투 대상자와 `Enemy`와의 거리가 떨어져 있거나 전투에서 벗어날 경우 안보이도록 설정

#### Disable `Enemy`'s capsule collision when `Enemy` was dead
- `Enemy` 사망 시 capsule collision의 충돌 비활성화
     ```
     GetCapsuleComponent()->SetCollisionEnabled(ECollisionEnabled::NoCollision);
     ```