### PR TITLE
Implement Hitting the Character

### DIFF
--- a/Source/Slash/Private/Characters/SlashCharacter.cpp
+++ b/Source/Slash/Private/Characters/SlashCharacter.cpp
@@ -4,6 +4,7 @@
 #include "Characters/SlashCharacter.h"
 #include "Camera/CameraComponent.h"
 #include "GameFramework/CharacterMovementComponent.h"
+#include "Components/StaticMeshComponent.h"
 #include "GameFramework/SpringArmComponent.h"
 #include "Items/Item.h"
 #include "Items/Weapon.h"
@@ -20,6 +21,12 @@ ASlashCharacter::ASlashCharacter()
 
 	GetCharacterMovement()->bOrientRotationToMovement = true;
 	GetCharacterMovement()->RotationRate = FRotator(0.f, 1080.f, 0.f);
+
+	GetMesh()->SetCollisionObjectType(ECollisionChannel::ECC_WorldDynamic);
+	GetMesh()->SetCollisionResponseToAllChannels(ECollisionResponse::ECR_Ignore);
+	GetMesh()->SetCollisionResponseToChannel(ECollisionChannel::ECC_Visibility, ECollisionResponse::ECR_Block);
+	GetMesh()->SetCollisionResponseToChannel(ECollisionChannel::ECC_WorldDynamic, ECollisionResponse::ECR_Overlap);
+	GetMesh()->SetGenerateOverlapEvents(true);
 
 	CameraBoom = CreateDefaultSubobject<USpringArmComponent>(TEXT("CameraBoom"));
 	CameraBoom->SetupAttachment(GetRootComponent());
@@ -45,12 +52,17 @@ void ASlashCharacter::SetupPlayerInputComponent(UInputComponent* PlayerInputComp
 	PlayerInputComponent->BindAction(FName("Attack"), IE_Pressed, this, &ASlashCharacter::Attack);
 }
 
+void ASlashCharacter::GetHit_Implementation(const FVector& ImpactPoint)
+{
+	PlayHitSound(ImpactPoint);
+	SpawnHitParticle(ImpactPoint);
+}
+
 void ASlashCharacter::BeginPlay()
 {
 	Super::BeginPlay();
 
-	Tags.Add(FName("SlashCharacter"));
-	
+	Tags.Add(FName("EngageableTarget"));
 }
 
 void ASlashCharacter::MoveForward(float Value)

--- a/Source/Slash/Private/Enemies/Enemy.cpp
+++ b/Source/Slash/Private/Enemies/Enemy.cpp
@@ -96,6 +96,7 @@ void AEnemy::BeginPlay()
 		PawnSensing->OnSeePawn.AddDynamic(this, &AEnemy::PawnSeen);
 	}
 	InitializeEnemy();
+	Tags.Add(FName("Enemey"));
 }
 
 //Enemy Death 실행
@@ -328,7 +329,7 @@ void AEnemy::PawnSeen(APawn* SeenPawn)
 		!IsDead() &&
 			!IsChasing()&&
 				EnemyState < EEnemyState::EES_Attacking &&
-					SeenPawn->ActorHasTag(FName("SlashCharacter"));
+					SeenPawn->ActorHasTag(FName("EngageableTarget"));
 	if(bShouldChaseTarget)
 	{
 		CombatTarget = SeenPawn;

--- a/Source/Slash/Private/Items/Treasure.cpp
+++ b/Source/Slash/Private/Items/Treasure.cpp
@@ -7,20 +7,25 @@
 #include "Kismet/GameplayStatics.h"
 #include "Components/StaticMeshComponent.h"
 
+void ATreasure::PlayCoinSound()
+{
+	if(PickupSound)
+	{
+		UGameplayStatics::PlaySoundAtLocation(
+			GetWorld(),
+			PickupSound,
+			GetActorLocation()
+		);
+	}
+}
+
 void ATreasure::OnSphereOverlap(UPrimitiveComponent* OverlappedComponent, AActor* OtherActor,
-	UPrimitiveComponent* OtherComp, int32 OtherBodyIndex, bool bFromSweep, const FHitResult& SweepResult)
+                                UPrimitiveComponent* OtherComp, int32 OtherBodyIndex, bool bFromSweep, const FHitResult& SweepResult)
 {
 	ASlashCharacter* SlashCharacter = Cast<ASlashCharacter>(OtherActor);
 	if(SlashCharacter)
 	{
-		if(PickupSound)
-		{
-			UGameplayStatics::PlaySoundAtLocation(
-				GetWorld(),
-				PickupSound,
-				GetActorLocation()
-				);
-		}
+		PlayCoinSound();
 		Destroy(this);
 	}
 }

--- a/Source/Slash/Public/Characters/BaseCharacter.h
+++ b/Source/Slash/Public/Characters/BaseCharacter.h
@@ -57,18 +57,18 @@ private:
 	void PlayMontageSection(UAnimMontage* Montage, FName SectionName);
 	int32 PlayRandomMontageSection(UAnimMontage* Montage);
 
-	UPROPERTY(EditAnywhere, Category = Sounds)
+	UPROPERTY(EditAnywhere, Category = Combat)
 	USoundBase* HitSound;
 
-	UPROPERTY(EditAnywhere, Category = VisualEffects)
+	UPROPERTY(EditAnywhere, Category = Combat)
 	UParticleSystem* HitParticles;
 
-	UPROPERTY(EditDefaultsOnly, Category = Montages)
+	UPROPERTY(EditDefaultsOnly, Category = Combat)
 	UAnimMontage* AttackMontage;
 
-	UPROPERTY(EditDefaultsOnly, Category = Montages)
+	UPROPERTY(EditDefaultsOnly, Category = Combat)
 	UAnimMontage* HitReactMontage;
 
-	UPROPERTY(EditDefaultsOnly, Category = Montages)
+	UPROPERTY(EditDefaultsOnly, Category = Combat)
 	TArray<UAnimMontage*> DeathMontages;
 };

--- a/Source/Slash/Public/Characters/SlashCharacter.h
+++ b/Source/Slash/Public/Characters/SlashCharacter.h
@@ -21,7 +21,8 @@ class SLASH_API ASlashCharacter : public ABaseCharacter
 public:
 	ASlashCharacter();
 	virtual void SetupPlayerInputComponent(class UInputComponent* PlayerInputComponent) override;
-	
+
+	virtual void GetHit_Implementation(const FVector& ImpactPoint) override;
 protected:
 	virtual void BeginPlay() override;
 

--- a/Source/Slash/Public/Items/Treasure.h
+++ b/Source/Slash/Public/Items/Treasure.h
@@ -15,8 +15,9 @@ class SLASH_API ATreasure : public AItem
 {
 	GENERATED_BODY()
 protected:
+	void PlayCoinSound();
 	virtual void OnSphereOverlap(UPrimitiveComponent* OverlappedComponent, AActor* OtherActor,
-		UPrimitiveComponent* OtherComp, int32 OtherBodyIndex, bool bFromSweep, const FHitResult& SweepResult) override;
+	                             UPrimitiveComponent* OtherComp, int32 OtherBodyIndex, bool bFromSweep, const FHitResult& SweepResult) override;
 	virtual void OnSphereEndOverlap(UPrimitiveComponent* OverlappedComponent, AActor* OtherActor,
 		UPrimitiveComponent* OtherComp, int32 OtherBodyIndex) override;
 private:

--- a/Source/Slash/Public/Items/Weapon.h
+++ b/Source/Slash/Public/Items/Weapon.h
@@ -1,59 +1,66 @@
-// Fill out your copyright notice in the Description page of Project Settings.
-
 #pragma once
 
 #include "CoreMinimal.h"
 #include "Items/Item.h"
-#include "WeaponTypes.h"
 #include "Weapon.generated.h"
 
+class USoundBase;
 class UBoxComponent;
+class USceneComponent;
+
 /**
  * 
  */
-class USoundBase;
-class USceneComponent;
 UCLASS()
 class SLASH_API AWeapon : public AItem
 {
 	GENERATED_BODY()
 public:
 	AWeapon();
-	void AttachMeshToSocket(USceneComponent* InParent, FName InSocketName);
 	void Equip(USceneComponent* InParent, FName InSocketName, AActor* NewOwner, APawn* NewInstigator);
+	void DeactivateEmbers();
+	void DisableSphereCollision();
+	void PlayEquipSound();
+	void AttachMeshToSocket(USceneComponent* InParent, const FName& InSocketName);
 
 	TArray<AActor*> IgnoreActors;
-
 protected:
 	virtual void BeginPlay() override;
-	virtual void OnSphereOverlap(UPrimitiveComponent* OverlappedComponent, AActor* OtherActor, UPrimitiveComponent* OtherComp, int32 OtherBodyIndex, bool bFromSweep, const FHitResult & SweepResult) override;
-	virtual void OnSphereEndOverlap(UPrimitiveComponent* OverlappedComponent, AActor* OtherActor, UPrimitiveComponent* OtherComp, int32 OtherBodyIndex) override;
-	UFUNCTION()
-	virtual void OnBoxOverlap(UPrimitiveComponent* OverlappedComponent, AActor* OtherActor, UPrimitiveComponent* OtherComp, int32 OtherBodyIndex, bool bFromSweep, const FHitResult & SweepResult);
-	UFUNCTION()
-	virtual void OnBoxEndOverlap(UPrimitiveComponent* OverlappedComponent, AActor* OtherActor, UPrimitiveComponent* OtherComp, int32 OtherBodyIndex);
-	UFUNCTION(BlueprintImplementableEvent)
-	void CreateField(const FVector& FieldLocation);
 
+	UFUNCTION()
+	void OnBoxOverlap(UPrimitiveComponent* OverlappedComponent, AActor* OtherActor, UPrimitiveComponent* OtherComp, int32 OtherBodyIndex, bool bFromSweep, const FHitResult& SweepResult);
+
+	bool ActorIsSameType(AActor* OtherActor);
+
+	void ExecuteGetHit(FHitResult& BoxHit);
+
+	UFUNCTION(BlueprintImplementableEvent)
+	void CreateFields(const FVector& FieldLocation);
 private:
-	UPROPERTY(EditAnywhere, Category="Weapon Properties")
+
+	void BoxTrace(FHitResult& BoxHit);
+
+	UPROPERTY(EditAnywhere, Category = "Weapon Properties")
+	FVector BoxTraceExtent = FVector(5.f);
+
+	UPROPERTY(EditAnywhere, Category = "Weapon Properties")
+	bool bShowBoxDebug = false;
+
+	UPROPERTY(EditAnywhere, Category = "Weapon Properties")
 	USoundBase* EquipSound;
 
-	UPROPERTY(VisibleAnywhere, Category="Weapon Properties")
+	UPROPERTY(VisibleAnywhere, Category = "Weapon Properties")
 	UBoxComponent* WeaponBox;
-	
 
 	UPROPERTY(VisibleAnywhere)
 	USceneComponent* BoxTraceStart;
-	
+
 	UPROPERTY(VisibleAnywhere)
 	USceneComponent* BoxTraceEnd;
 
-	UPROPERTY(EditAnywhere, Category="Weapon Properties")
+	UPROPERTY(EditAnywhere, Category = "Weapon Properties")
 	float Damage = 20.f;
 
 public:
-	FORCEINLINE UBoxComponent* GetWeaponBox() const {return WeaponBox; }
+	FORCEINLINE UBoxComponent* GetWeaponBox() const { return WeaponBox; }
 };
-
-


### PR DESCRIPTION
- #30
### 변경사항
- [x] `Enemy` 가 `SlahsCharacter`에게 피해를 주도록 구현
- `SlahsCharacter`에 `GetHit_Implementation` 구현
- 같은 `Enemy`끼리의 피격을 회피
- 
  ```C++
  bool AWeapon::ActorIsSameType(AActor* OtherActor)
  {
	  return GetOwner()->ActorHasTag(TEXT("Enemy")) && OtherActor->ActorHasTag(TEXT("Enemy"));
  }
  ```
- 일부 코드 리팩토링