### PR TITLE
Implement Hit Reaction State

### DIFF
--- a/Source/Slash/Private/Characters/SlashCharacter.cpp
+++ b/Source/Slash/Private/Characters/SlashCharacter.cpp
@@ -55,6 +55,8 @@ void ASlashCharacter::SetupPlayerInputComponent(UInputComponent* PlayerInputComp
 void ASlashCharacter::GetHit_Implementation(const FVector& ImpactPoint)
 {
 	Super::GetHit_Implementation(ImpactPoint);
+
+	ActionState = EActionState::EAS_HitReaction;
 }
 
 void ASlashCharacter::BeginPlay()
@@ -218,6 +220,11 @@ void ASlashCharacter::PlayEquipMontage(const FName& SectionName)
 }
 
 void ASlashCharacter::FinishEquipping()
+{
+	ActionState = EActionState::EAS_Unoccupied;
+}
+
+void ASlashCharacter::HitReactEnd()
 {
 	ActionState = EActionState::EAS_Unoccupied;
 }

--- a/Source/Slash/Private/Enemies/Enemy.cpp
+++ b/Source/Slash/Private/Enemies/Enemy.cpp
@@ -58,6 +58,7 @@ void AEnemy::GetHit_Implementation(const FVector& ImpactPoint)
 {
 	Super::GetHit_Implementation(ImpactPoint);
 	SetHealthBarVisible(true);
+	ClearPatrolTimer();
 }
 
 /*
@@ -100,6 +101,7 @@ void AEnemy::Die()
 	DisableCapsule();
 	SetLifeSpan(DeathLifeSpan);
 	GetCharacterMovement()->bOrientRotationToMovement = false;
+	SetWeaponCollisionEnabled(ECollisionEnabled::NoCollision);
 }
 
 void AEnemy::Attack()

--- a/Source/Slash/Private/Enemies/Enemy.cpp
+++ b/Source/Slash/Private/Enemies/Enemy.cpp
@@ -58,7 +58,7 @@ void AEnemy::Tick(float DeltaTime)
 void AEnemy::GetHit_Implementation(const FVector& ImpactPoint)
 {
 	Super::GetHit_Implementation(ImpactPoint);
-	SetHealthBarVisible(true);
+	if(!IsDead()) SetHealthBarVisible(true);
 	ClearPatrolTimer();
 }
 

--- a/Source/Slash/Public/Characters/CharacterTypes.h
+++ b/Source/Slash/Public/Characters/CharacterTypes.h
@@ -12,6 +12,7 @@ UENUM(BlueprintType)
 enum class EActionState : uint8
 {
 	EAS_Unoccupied UMETA(DisplayName = "Unoccupied"),
+	EAS_HitReaction UMETA(DisplayName = "HitReaction"),
 	EAS_Attacking UMETA(DisplayName = "Attacking"),
 	EAS_EquippingWeapon UMETA(DisplayName = "Equipping Weapon")
 };

--- a/Source/Slash/Public/Characters/SlashCharacter.h
+++ b/Source/Slash/Public/Characters/SlashCharacter.h
@@ -54,6 +54,9 @@ protected:
 	UFUNCTION(BlueprintCallable)
 	void FinishEquipping();
 
+	UFUNCTION(BlueprintCallable)
+	void HitReactEnd();
+
 private:	
 	UPROPERTY(VisibleAnywhere)
 	USpringArmComponent* CameraBoom;


### PR DESCRIPTION
- #41 
- #40  
### 변경사항
- [x] `SlashCharacter` 피격 시 이벤트 추가
- [x] 피격 도중 공격 불가 처리 - HitReact State 추가

`Enemy` 피격 중 Patrol Timer 초과 시 이동 및 공격 애니메이션이 겹치는 버그 수정
`Enemy` 사망 시 체력바 사라지지 않는 버그 수정